### PR TITLE
Fix promoted link tile text cutoff

### DIFF
--- a/Georgian.StudentPortal.ResponsiveUI/ResponsiveUI/GC_responsive_ui.css
+++ b/Georgian.StudentPortal.ResponsiveUI/ResponsiveUI/GC_responsive_ui.css
@@ -2256,3 +2256,8 @@ div.QuickLinks .WebPartHeading {
     background-color: inherit;
     }
 }
+
+/* Promoted links tile text cutoff fix */
+.ms-tileview-tile-titleTextSmallCollapsed, .ms-tileview-tile-titleTextMediumCollapsed{
+ max-height: none !important;   
+}


### PR DESCRIPTION
Fixes letters like g or y or p being cut off on tiles with two lines. http://i.imgur.com/yj7Z4ax.png